### PR TITLE
Refine landing page into a premium minimal experience

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,15 +3,126 @@
 @tailwind utilities;
 
 :root {
-  --bg: #0F172A;
-  --fg: #F1F5F9;
+  color-scheme: dark;
+  background-color: #0F172A;
+  color: #F1F5F9;
 }
 
-html, body { height: 100%; }
-body { color: var(--fg); background: var(--bg); }
+* {
+  box-sizing: border-box;
+}
 
-.container-narrow { @apply max-w-3xl mx-auto px-4; }
-.card { @apply bg-white/5 border border-white/10 rounded-2xl p-6 shadow-lg; }
-.btn { @apply inline-flex items-center justify-center rounded-xl px-4 py-2 font-medium border border-white/15 bg-white/10 hover:bg-white/20 transition; }
-.btn-primary { @apply bg-halo text-ink hover:bg-amber-400 border-transparent; }
-.link { @apply underline decoration-white/30 underline-offset-4 hover:decoration-halo; }
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 1rem;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  background-color: #0F172A;
+  color: #F1F5F9;
+}
+
+main {
+  flex: 1 1 auto;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover {
+  color: inherit;
+}
+
+.container-page {
+  @apply mx-auto w-full max-w-[72rem] px-6 md:px-12;
+}
+
+.section {
+  @apply py-24 md:py-32;
+}
+
+.btn {
+  @apply inline-flex min-h-[2.75rem] min-w-[2.75rem] items-center justify-center rounded-full border border-white/10 bg-white/10 px-5 py-3 text-base font-medium text-cloud/90 transition duration-200 ease-out hover:text-cloud focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-halo motion-reduce:transition-none;
+}
+
+.btn-primary {
+  @apply bg-halo text-ink shadow-[0_10px_30px_-20px_rgba(245,158,11,0.65)] hover:bg-amber-300 focus-visible:outline-offset-2;
+}
+
+.badge {
+  @apply inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm font-medium text-cloud/80;
+}
+
+.badge::before {
+  content: "";
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.95), rgba(245, 158, 11, 0.6));
+  box-shadow: 0 0 12px rgba(245, 158, 11, 0.6);
+}
+
+.halo-orb {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.halo-orb::before {
+  content: "";
+  position: absolute;
+  inset-inline-start: 20%;
+  inset-block-start: 25%;
+  width: clamp(18rem, 40vw, 28rem);
+  aspect-ratio: 1 / 1;
+  background: radial-gradient(circle at 30% 30%, rgba(245, 158, 11, 0.55), rgba(15, 23, 42, 0));
+  filter: blur(48px);
+  opacity: 0.75;
+  transform: translate3d(0, 0, 0) scale(1);
+  transition: opacity 300ms ease, transform 1000ms ease;
+  animation: haloPulse 12s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .halo-orb::before {
+    animation: none;
+    transition: none;
+  }
+}
+
+@keyframes haloPulse {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(0.95);
+    opacity: 0.6;
+  }
+  50% {
+    transform: translate3d(0, -3%, 0) scale(1.05);
+    opacity: 0.85;
+  }
+}
+
+.card-surface {
+  @apply rounded-[2rem] border border-white/10 bg-white/[0.03] p-10 shadow-[0_25px_60px_-40px_rgba(15,23,42,0.8)] backdrop-blur;
+}
+
+.surface-panel {
+  @apply rounded-3xl border border-white/[0.08] bg-white/[0.04] p-8 shadow-[0_18px_48px_-36px_rgba(15,23,42,0.9)] transition duration-200 ease-out hover:-translate-y-0.5 hover:shadow-lift motion-reduce:transform-none motion-reduce:shadow-none;
+}
+
+.link-inline {
+  @apply underline decoration-white/20 underline-offset-[6px] transition-colors hover:decoration-white/50;
+}
+
+input::placeholder {
+  color: rgba(241, 245, 249, 0.55);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,54 +3,63 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "HaloHub — Give families back their time",
-  description: "A trust network where people and ethical AI direct money, time, and skills to the next most helpful thing — transparently and safely.",
+  description:
+    "A trust network where people and ethical AI direct money, time, and skills to the next most helpful thing — transparently and safely.",
   openGraph: {
     title: "HaloHub",
     description: "Open, fair, safe help for families — one account for giving and receiving.",
     url: "https://halohub.com",
     siteName: "HaloHub",
     images: [{ url: "/og.svg", width: 1200, height: 630, alt: "HaloHub" }],
-    type: "website"
+    type: "website",
   },
   twitter: {
     card: "summary_large_image",
     title: "HaloHub",
     description: "Give families back their time.",
-  }
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body>
-        <header className="container-narrow py-6 flex items-center justify-between">
-          <a href="/" className="flex items-center gap-3">
-            <svg width="28" height="28" viewBox="0 0 24 24" aria-hidden="true">
-              <defs>
-                <radialGradient id="haloGrad" cx="50%" cy="50%" r="50%">
-                  <stop offset="0%" stopColor="#F59E0B" />
-                  <stop offset="100%" stopColor="#F97316" />
-                </radialGradient>
-              </defs>
-              <circle cx="12" cy="12" r="10" fill="url(#haloGrad)" opacity="0.9" />
-              <circle cx="12" cy="12" r="5" fill="none" stroke="white" strokeOpacity="0.6" />
-            </svg>
-            <span className="text-xl font-semibold">HaloHub</span>
-          </a>
-          <nav className="flex items-center gap-4 text-sm text-white/80">
-            <a className="hover:text-white" href="/trust-safety">Trust & Safety</a>
-            <a className="hover:text-white" href="/transparency">Transparency</a>
-            <a className="btn" href="#waitlist">Get early access</a>
-          </nav>
+    <html lang="en" className="bg-ink text-cloud">
+      <body className="flex min-h-screen flex-col font-sans antialiased">
+        <header className="py-8 md:py-10">
+          <div className="container-page flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+            <a href="/" className="flex items-center gap-3 text-sm font-medium text-cloud/70 transition hover:text-cloud">
+              <span className="relative flex h-11 w-11 items-center justify-center rounded-full border border-white/10 bg-white/[0.06]">
+                <span className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_30%,rgba(245,158,11,0.9),rgba(15,23,42,0.2))] opacity-80 blur-xl" aria-hidden="true" />
+                <span className="relative block h-4 w-4 rounded-full border border-white/50 bg-white/90" aria-hidden="true" />
+              </span>
+              <span className="text-lg tracking-tight">HaloHub</span>
+            </a>
+            <nav className="flex flex-wrap items-center gap-3 text-sm text-cloud/70">
+              <a className="link-inline" href="/trust-safety">
+                Trust &amp; Safety
+              </a>
+              <a className="link-inline" href="/transparency">
+                Transparency
+              </a>
+              <a className="btn btn-primary" href="#waitlist">
+                Join the pilot
+              </a>
+            </nav>
+          </div>
         </header>
         <main>{children}</main>
-        <footer className="container-narrow py-10 text-white/60 text-sm">
-          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-            <p>© {new Date().getFullYear()} HaloHub. Mission-driven. Open by default.</p>
-            <div className="flex gap-4">
-              <a className="link" href="/trust-safety">Ethics & Safety</a>
-              <a className="link" href="/transparency">Transparency Log</a>
-              <a className="link" href="mailto:hello@halohub.com">Contact</a>
+        <footer className="py-12">
+          <div className="container-page flex flex-col gap-4 text-sm text-cloud/60 md:flex-row md:items-center md:justify-between">
+            <p>© {new Date().getFullYear()} HaloHub. Purpose-built, transparent, safe.</p>
+            <div className="flex flex-wrap items-center gap-4">
+              <a className="link-inline" href="/trust-safety">
+                Ethics &amp; Safety
+              </a>
+              <a className="link-inline" href="/transparency">
+                Transparency Log
+              </a>
+              <a className="link-inline" href="mailto:hello@halohub.com">
+                Contact
+              </a>
             </div>
           </div>
         </footer>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,54 +1,179 @@
 import RoleToggle from "@/components/RoleToggle";
 import EmailCapture from "@/components/EmailCapture";
 
+const features = [
+  {
+    title: "Dignity-first requests",
+    description:
+      "Reflective prompts help families articulate what returns hours to their week — without having to plead in public.",
+    icon: (
+      <svg viewBox="0 0 32 32" className="h-9 w-9 text-cloud/80" aria-hidden="true">
+        <path
+          d="M9 11.5c0-3.59 2.91-6.5 6.5-6.5s6.5 2.91 6.5 6.5c0 1.8-.73 3.43-1.91 4.61-1.18 1.18-1.91 2.81-1.91 4.61"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+        <path
+          d="M16 25.5v.01"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    title: "Fair, open allocation",
+    description:
+      "The HALO Engine pools donations and applies human-readable reason codes so you can see why every decision was made.",
+    icon: (
+      <svg viewBox="0 0 32 32" className="h-9 w-9 text-cloud/80" aria-hidden="true">
+        <path
+          d="M8.5 22.5h15M8.5 16h15M8.5 9.5h15"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+        <path
+          d="M12 12.5c0-2.21 1.79-4 4-4s4 1.79 4 4-1.79 4-4 4-4-1.79-4-4Z"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        />
+      </svg>
+    ),
+  },
+  {
+    title: "Safety with real receipts",
+    description:
+      "Helpers earn trust through progressive verification, service proofs, and shared safety oversight.",
+    icon: (
+      <svg viewBox="0 0 32 32" className="h-9 w-9 text-cloud/80" aria-hidden="true">
+        <path
+          d="M16 5.5 7 10v6c0 6.22 4.07 11.89 9 13.5 4.93-1.61 9-7.28 9-13.5v-6l-9-4.5Z"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        <path
+          d="m12.75 16.25 2.25 2.25 4.25-4.25"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    ),
+  },
+];
+
+const receipts = [
+  "Open algorithms with human-readable reason codes",
+  "Append-only impact ledger with privacy by design",
+  "Community Safety Council and published incident log",
+  "Progressive verification with anti-gaming audits",
+  "Profit caps and reinvestment mandate",
+  "External reviews and quarterly transparency notes",
+];
+
 export default function Home() {
   return (
     <>
-      <section className="container-narrow pt-14 pb-6">
-        <div className="card relative overflow-hidden">
-          <div className="absolute -inset-1 rounded-3xl bg-gradient-to-br from-halo/20 to-coral/10 blur-3xl" aria-hidden="true"/>
-          <div className="relative">
-            <h1 className="text-3xl sm:text-5xl font-bold tracking-tight">Give families back their time.</h1>
-            <p className="mt-4 text-white/80 text-lg max-w-2xl">
-              HaloHub is a trust network where people and ethical AI direct money, time, and skills to what helps most — openly and safely.
-              One account can give and receive. Switch perspectives any time.
-            </p>
-            <div id="waitlist" className="mt-4">
-              <EmailCapture />
+      <section className="section relative overflow-hidden">
+        <div className="container-page">
+          <div className="card-surface relative isolate overflow-hidden">
+            <div className="halo-orb" aria-hidden="true" />
+            <div className="relative flex flex-col gap-10">
+              <div className="max-w-2xl space-y-6">
+                <h1 className="text-balance text-[clamp(2.5rem,6vw,4rem)] font-semibold leading-[1.05] tracking-tight">
+                  Give families back their time.
+                </h1>
+                <p className="text-lg text-cloud/80 md:text-xl">
+                  HaloHub is the trust network where people and ethical AI direct money, time, and skills to what helps most —
+                  openly and safely. One account can give and receive. Switch perspectives any time.
+                </p>
+              </div>
+              <div className="space-y-4">
+                <div id="waitlist">
+                  <EmailCapture />
+                </div>
+                <div className="flex flex-wrap items-center gap-4 text-sm text-cloud/70">
+                  <a className="link-inline" href="/trust-safety">
+                    Explore our Trust &amp; Safety commitments
+                  </a>
+                  <span className="text-cloud/40">or</span>
+                  <a className="link-inline text-cloud/70" href="/transparency">
+                    Read the transparency log
+                  </a>
+                </div>
+                <p className="text-sm text-cloud/50">
+                  We send minimal, privacy-respecting email. Opt out anytime.
+                </p>
+              </div>
             </div>
-            <p className="mt-2 text-xs text-white/60">We use minimal, privacy-respecting email. No spam. Opt out anytime.</p>
           </div>
         </div>
       </section>
 
-      <section className="container-narrow grid sm:grid-cols-3 gap-4 mt-4">
-        <div className="card">
-          <h3 className="font-semibold">Dignity-first</h3>
-          <p className="text-white/80 mt-2">Reflective prompts → well-formed requests you approve. No begging, no popularity contests.</p>
-        </div>
-        <div className="card">
-          <h3 className="font-semibold">Fair & transparent</h3>
-          <p className="text-white/80 mt-2">Donations are pooled and allocated by the HALO Engine with public reason codes and an open ledger.</p>
-        </div>
-        <div className="card">
-          <h3 className="font-semibold">Safe skills</h3>
-          <p className="text-white/80 mt-2">Helpers offer time or expertise with safeguards, ratings, and progressive verification.</p>
+      <section className="section pt-0">
+        <div className="container-page">
+          <div className="grid gap-6 md:grid-cols-3">
+            {features.map((feature) => (
+              <article key={feature.title} className="surface-panel h-full">
+                <div className="flex flex-col gap-6">
+                  <span className="flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.06]">
+                    {feature.icon}
+                  </span>
+                  <div className="space-y-3">
+                    <h3 className="text-xl font-semibold tracking-tight text-cloud">
+                      {feature.title}
+                    </h3>
+                    <p className="text-base leading-relaxed text-cloud/75">{feature.description}</p>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
         </div>
       </section>
 
-      <RoleToggle />
+      <section className="section">
+        <RoleToggle />
+      </section>
 
-      <section className="container-narrow mt-10 mb-8">
-        <div className="card">
-          <h2 className="text-lg font-semibold">Trust, safety, and receipts for impact</h2>
-          <ul className="list-disc pl-5 mt-3 text-white/80 space-y-1">
-            <li>Open algorithms with human-readable reason codes.</li>
-            <li>Append-only public impact ledger (anonymized recipients).</li>
-            <li>Community Safety Council, incident log, and profit caps.</li>
-          </ul>
-          <div className="mt-4 flex gap-3">
-            <a className="btn" href="/trust-safety">Trust & Safety</a>
-            <a className="btn" href="/transparency">Transparency Log</a>
+      <section className="section pt-0">
+        <div className="container-page space-y-10">
+          <div className="flex flex-wrap items-center gap-4">
+            <h2 className="text-3xl font-semibold tracking-tight text-cloud">Trust, safety, and receipts for impact</h2>
+            <span className="badge">Reason codes = receipts for impact</span>
+          </div>
+          <div className="grid gap-6 lg:grid-cols-2">
+            {receipts.map((item) => (
+              <div
+                key={item}
+                className="flex items-start gap-4 rounded-3xl border border-white/[0.08] bg-white/[0.03] p-6 text-base text-cloud/80"
+              >
+                <span
+                  className="mt-1 inline-flex h-3 w-3 flex-none items-center justify-center rounded-full border border-halo/60 bg-halo/40 shadow-[0_0_12px_rgba(245,158,11,0.6)]"
+                  aria-hidden="true"
+                />
+                <p className="leading-relaxed">{item}</p>
+              </div>
+            ))}
+          </div>
+          <div className="flex flex-wrap items-center gap-4">
+            <a className="btn" href="/trust-safety">
+              Trust &amp; Safety
+            </a>
+            <a className="btn" href="/transparency">
+              Transparency Log
+            </a>
           </div>
         </div>
       </section>

--- a/app/transparency/page.tsx
+++ b/app/transparency/page.tsx
@@ -1,13 +1,29 @@
-export const dynamic = 'force-static';
+export const dynamic = "force-static";
 
 export default function Transparency() {
   return (
-    <div className="container-narrow py-12">
-      <h1 className="text-3xl font-bold">Transparency Log</h1>
-      <div className="mt-6 card">
-        <p className="text-sm text-white/70">2025-10-05 — Policy — Launched public log and governance stubs.</p>
-        <p className="mt-2 text-white/90">We’ll record incidents, fixes, and algorithm updates here with redactions for privacy.</p>
+    <section className="section">
+      <div className="container-page max-w-3xl space-y-12">
+        <header className="space-y-3">
+          <p className="text-sm text-cloud/50">Log opened October 5, 2025</p>
+          <h1 className="text-4xl font-semibold tracking-tight text-cloud">Transparency Log</h1>
+          <p className="text-lg leading-relaxed text-cloud/75">
+            We record incidents, fixes, and algorithm updates with redactions only when needed for privacy. Every entry includes
+            a reason code so anyone can trace impact.
+          </p>
+        </header>
+        <article className="space-y-4 rounded-[2rem] border border-white/10 bg-white/[0.03] p-10 text-base leading-relaxed text-cloud/80 shadow-[0_25px_60px_-40px_rgba(15,23,42,0.8)]">
+          <header className="flex flex-wrap items-center gap-3 text-sm text-cloud/60">
+            <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1">2025-10-05</span>
+            <span>Policy</span>
+          </header>
+          <h2 className="text-2xl font-semibold tracking-tight text-cloud">Launched public log and governance stubs</h2>
+          <p>
+            We’ll expand this ledger with impact summaries, algorithm changes, and safety council decisions. Each update ships
+            with rationale, mitigation steps, and how we measured follow-up.
+          </p>
+        </article>
       </div>
-    </div>
+    </section>
   );
 }

--- a/app/trust-safety/page.tsx
+++ b/app/trust-safety/page.tsx
@@ -1,18 +1,41 @@
-export const dynamic = 'force-static';
+export const dynamic = "force-static";
 
 export default function TrustSafety() {
   return (
-    <div className="container-narrow py-12">
-      <h1 className="text-3xl font-bold">Trust & Safety</h1>
-      <p className="mt-4 text-white/80">We bake safety, fairness, and transparency into HaloHub’s DNA.</p>
-      <ul className="mt-6 space-y-3 text-white/90">
-        <li>• Open & explainable HALO Engine (reason codes on allocations)</li>
-        <li>• Privacy-preserving, public impact ledger (no identities)</li>
-        <li>• Progressive verification and anti-gaming safeguards</li>
-        <li>• Community Safety Council and public incident log</li>
-        <li>• Profit caps and reinvestment mandate</li>
-      </ul>
-      <p className="mt-6 text-white/60 text-sm">Full policies will be published and versioned as we open the pilot.</p>
-    </div>
+    <section className="section">
+      <div className="container-page max-w-3xl space-y-12">
+        <header className="space-y-3">
+          <p className="text-sm text-cloud/50">Updated October 5, 2025</p>
+          <h1 className="text-4xl font-semibold tracking-tight text-cloud">Trust &amp; Safety</h1>
+          <p className="text-lg leading-relaxed text-cloud/75">
+            We bake safety, fairness, and transparency into HaloHub’s DNA. Policies stay concise, auditable, and accountable to
+            the community.
+          </p>
+        </header>
+        <article className="space-y-6 rounded-[2rem] border border-white/10 bg-white/[0.03] p-10 text-base leading-relaxed text-cloud/80 shadow-[0_25px_60px_-40px_rgba(15,23,42,0.8)]">
+          <section className="space-y-3">
+            <h2 className="text-2xl font-semibold tracking-tight text-cloud">Safety guardrails</h2>
+            <p>
+              The HALO Engine remains explainable by design. Every allocation publishes a reason code that humans can read and
+              audit. Families review requests before anything is shared.
+            </p>
+          </section>
+          <section className="space-y-3">
+            <h2 className="text-2xl font-semibold tracking-tight text-cloud">Community oversight</h2>
+            <p>
+              We maintain a privacy-preserving public impact ledger and empower a Community Safety Council to review incidents,
+              publish findings, and require remediation. Progressive verification prevents gaming.
+            </p>
+          </section>
+          <section className="space-y-3">
+            <h2 className="text-2xl font-semibold tracking-tight text-cloud">Mission lock</h2>
+            <p>
+              HaloHub operates with profit caps and reinvestment mandates so incentives stay aligned with the families we serve.
+              Full policies will be published and versioned as we open the pilot.
+            </p>
+          </section>
+        </article>
+      </div>
+    </section>
   );
 }

--- a/components/EmailCapture.tsx
+++ b/components/EmailCapture.tsx
@@ -1,36 +1,100 @@
 "use client";
+
 import { useState } from "react";
 
-export default function EmailCapture() {
-  const [status, setStatus] = useState<"idle"|"loading"|"success"|"error">("idle");
+type Status = "idle" | "loading" | "success" | "error";
 
-  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    const form = e.currentTarget;
+export default function EmailCapture() {
+  const [status, setStatus] = useState<Status>("idle");
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
     const data = Object.fromEntries(new FormData(form).entries());
     setStatus("loading");
     try {
-      const res = await fetch("/api/subscribe", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) });
-      if (res.ok) { setStatus("success"); form.reset(); } else { setStatus("error"); }
-    } catch { setStatus("error"); }
+      const response = await fetch("/api/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (response.ok) {
+        setStatus("success");
+        form.reset();
+      } else {
+        setStatus("error");
+      }
+    } catch {
+      setStatus("error");
+    }
   }
 
   return (
-    <form onSubmit={onSubmit} className="w-full sm:flex gap-3 mt-4" aria-describedby="signup-desc">
-      <input className="flex-1 rounded-xl px-4 py-3 bg-white/10 border border-white/15 placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-halo"
-        type="email" name="email" placeholder="you@email.com" required aria-label="Email address" />
-      <select className="mt-3 sm:mt-0 rounded-xl px-3 py-3 bg-white/10 border border-white/15" name="role" aria-label="Role">
-        <option value="family">Family</option>
-        <option value="donor">Donor</option>
-        <option value="helper">Helper</option>
-        <option value="other">Other</option>
-      </select>
-      <button className="mt-3 sm:mt-0 btn btn-primary" type="submit" disabled={status==="loading"}>
-        {status === "loading" ? "Joining…" : "Join the pilot"}
-      </button>
-      <p id="signup-desc" className="sr-only">Join the HaloHub pilot waitlist.</p>
-      {status === "success" && <p className="mt-3 text-emerald-300">Thanks! We’ll be in touch soon.</p>}
-      {status === "error" && <p className="mt-3 text-rose-300">Something went wrong. Please try again.</p>}
-    </form>
+    <div className="space-y-3">
+      <form
+        onSubmit={onSubmit}
+        className="flex flex-col gap-3 sm:flex-row sm:items-center"
+        aria-describedby="waitlist-help"
+      >
+        <label htmlFor="email" className="sr-only">
+          Email address
+        </label>
+        <input
+          id="email"
+          className="w-full rounded-2xl border border-white/15 bg-white/[0.08] px-5 py-3.5 text-base text-cloud placeholder:text-cloud/50 transition-colors duration-200 ease-out focus:border-white/40 focus:bg-white/[0.12] focus:outline-none focus:ring-2 focus:ring-halo/80 motion-reduce:transition-none"
+          type="email"
+          name="email"
+          placeholder="you@email.com"
+          required
+          autoComplete="email"
+        />
+        <label htmlFor="role" className="sr-only">
+          Role
+        </label>
+        <select
+          id="role"
+          name="role"
+          className="w-full rounded-2xl border border-white/15 bg-white/[0.06] px-5 py-3.5 text-base text-cloud/80 transition-colors duration-200 ease-out focus:border-white/40 focus:outline-none focus:ring-2 focus:ring-halo/80 sm:w-auto motion-reduce:transition-none"
+          defaultValue="family"
+        >
+          <option value="family">Family</option>
+          <option value="donor">Donor</option>
+          <option value="helper">Helper</option>
+          <option value="other">Other</option>
+        </select>
+        <button
+          className="btn btn-primary sm:self-stretch"
+          type="submit"
+          disabled={status === "loading"}
+        >
+          {status === "loading" ? "Joining…" : "Join the pilot"}
+        </button>
+      </form>
+      <p id="waitlist-help" className="sr-only">
+        Join the HaloHub pilot waitlist.
+      </p>
+      <div className="min-h-[1.75rem] text-sm" aria-live="polite" role="status">
+        {status === "success" && (
+          <p className="flex items-center gap-2 text-emerald-300">
+            <span aria-hidden="true" className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-emerald-300/70">
+              <svg viewBox="0 0 20 20" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M5 10.5 8.25 14 15 6.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </span>
+            Thanks! We’ll be in touch soon.
+          </p>
+        )}
+        {status === "error" && (
+          <p className="flex items-center gap-2 text-rose-300">
+            <span aria-hidden="true" className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-rose-300/70">
+              <svg viewBox="0 0 20 20" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M6 6l8 8m0-8-8 8" strokeLinecap="round" />
+              </svg>
+            </span>
+            Something went wrong. Please try again.
+          </p>
+        )}
+      </div>
+    </div>
   );
 }

--- a/components/RoleToggle.tsx
+++ b/components/RoleToggle.tsx
@@ -1,57 +1,180 @@
 "use client";
-import { useState } from "react";
+
+import { useId, useMemo, useRef, useState } from "react";
 
 type Role = "family" | "donor" | "helper";
 
-function label(r: Role) { return r.charAt(0).toUpperCase() + r.slice(1); }
+type RoleContent = {
+  id: Role;
+  label: string;
+  intro: string;
+  points: string[];
+};
+
+const roles: RoleContent[] = [
+  {
+    id: "family",
+    label: "Family",
+    intro:
+      "Dignity-first prompts surface what truly gives you time back. You decide what goes live before anything moves.",
+    points: [
+      "“If dinner were covered tonight, how much time would you gain?”",
+      "“What recurring task steals your week?”",
+      "“What could spark your child’s curiosity off-screen?”",
+    ],
+  },
+  {
+    id: "donor",
+    label: "Donor",
+    intro: "Fund the mission. The HALO Engine allocates fairly with public, human-readable reason codes.",
+    points: [
+      "See hours reclaimed and projects built — not identities.",
+      "Open, auditable ledger with anonymized recipients.",
+      "Profit caps and reinvestment; mission-locked governance.",
+    ],
+  },
+  {
+    id: "helper",
+    label: "Helper",
+    intro:
+      "Offer skills or time — from tutoring to bike repair. Matching stays safe, fair, and reputation-driven.",
+    points: [
+      "Progressive verification builds trust.",
+      "Proof-of-service with random audits prevents exploitation.",
+      "Earn non-speculative HALO credits for impact.",
+    ],
+  },
+];
 
 export default function RoleToggle() {
-  const [role, setRole] = useState<Role>("family");
+  const [activeRole, setActiveRole] = useState<Role>("family");
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const tablistId = useId();
+  const panelBaseId = useId();
+
+  const activeIndex = useMemo(() => roles.findIndex((role) => role.id === activeRole), [activeRole]);
+  const thumbStyle = useMemo(
+    () => ({
+      width: `calc((100% - 0.5rem) / ${roles.length})`,
+      transform: `translateX(${activeIndex * 100}%)`,
+    }),
+    [activeIndex]
+  );
+
+  function focusTab(index: number) {
+    tabRefs.current[index]?.focus();
+    setActiveRole(roles[index]?.id ?? "family");
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLButtonElement>, index: number, role: Role) {
+    switch (event.key) {
+      case "ArrowLeft":
+      case "ArrowUp": {
+        event.preventDefault();
+        const next = (index - 1 + roles.length) % roles.length;
+        focusTab(next);
+        break;
+      }
+      case "ArrowRight":
+      case "ArrowDown": {
+        event.preventDefault();
+        const next = (index + 1) % roles.length;
+        focusTab(next);
+        break;
+      }
+      case "Home": {
+        event.preventDefault();
+        focusTab(0);
+        break;
+      }
+      case "End": {
+        event.preventDefault();
+        focusTab(roles.length - 1);
+        break;
+      }
+      case "Enter":
+      case " ": {
+        event.preventDefault();
+        setActiveRole(role);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  const activeContent = roles[activeIndex];
+
   return (
-    <section className="container-narrow mt-10">
-      <div className="card">
-        <div className="flex items-center justify-between gap-4 mb-6">
-          <h2 className="text-lg font-semibold">One account. Switch perspectives.</h2>
-          <div className="inline-flex rounded-xl bg-white/10 p-1 border border-white/15">
-            {(["family","donor","helper"] as Role[]).map((r) => (
-              <button key={r} onClick={() => setRole(r)}
-                className={`px-3 py-1.5 text-sm rounded-lg transition ${role===r?"bg-white text-ink":"text-white/80 hover:text-white"}`}
-                aria-pressed={role===r}>{label(r)}</button>
-            ))}
+    <div className="container-page">
+      <div className="card-surface space-y-10">
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div className="max-w-2xl space-y-3">
+            <h2 className="text-3xl font-semibold tracking-tight text-cloud">One account. Switch perspectives.</h2>
+            <p className="text-base text-cloud/70">
+              Change what helps you today — and help someone else tomorrow. That’s the HALO loop.
+            </p>
+          </div>
+          <div
+            role="tablist"
+            aria-label="Select a HaloHub perspective"
+            className="relative isolate grid grid-cols-3 gap-0 rounded-full border border-white/12 bg-white/[0.06] p-1 text-sm shadow-inner shadow-black/20"
+            id={tablistId}
+          >
+            <span
+              className="pointer-events-none absolute inset-y-1 left-1 rounded-full bg-cloud text-ink shadow-[0_18px_45px_-30px_rgba(241,245,249,0.85)] transition-transform duration-300 ease-out motion-reduce:transition-none"
+              style={thumbStyle}
+              aria-hidden="true"
+            />
+            {roles.map((role, index) => {
+              const isActive = role.id === activeRole;
+              return (
+                <button
+                  key={role.id}
+                  ref={(el) => {
+                    tabRefs.current[index] = el;
+                  }}
+                  id={`${tablistId}-${role.id}`}
+                  role="tab"
+                  type="button"
+                  aria-selected={isActive}
+                  aria-controls={`${panelBaseId}-${role.id}`}
+                  tabIndex={isActive ? 0 : -1}
+                  onClick={() => setActiveRole(role.id)}
+                  onKeyDown={(event) => handleKeyDown(event, index, role.id)}
+                  className={`relative z-10 flex min-h-[2.75rem] items-center justify-center rounded-full px-5 py-3 font-medium transition-colors duration-200 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-halo motion-reduce:transition-none ${
+                    isActive ? "text-ink" : "text-cloud/70 hover:text-cloud"
+                  }`}
+                >
+                  {role.label}
+                </button>
+              );
+            })}
           </div>
         </div>
-        {role === "family" && (
-          <div className="space-y-3 text-white/90">
-            <p><strong>Dignity-first prompts</strong> surface what truly gives you time back. You approve requests before anything moves.</p>
-            <ul className="list-disc pl-5 space-y-1 text-white/80">
-              <li>“If dinner were covered tonight, how much time would you gain?”</li>
-              <li>“What recurring task steals your week?”</li>
-              <li>“What could spark your child’s curiosity off-screen?”</li>
-            </ul>
-          </div>
-        )}
-        {role === "donor" && (
-          <div className="space-y-3 text-white/90">
-            <p>Fund the <strong>mission</strong>. The HALO Engine allocates fairly with public reason codes.</p>
-            <ul className="list-disc pl-5 space-y-1 text-white/80">
-              <li>See <em>hours reclaimed</em> and <em>projects built</em> — not identities.</li>
-              <li>Open, auditable ledger with anonymized recipients.</li>
-              <li>Profit caps & reinvestment; mission-locked governance.</li>
-            </ul>
-          </div>
-        )}
-        {role === "helper" && (
-          <div className="space-y-3 text-white/90">
-            <p>Offer skills or time (bike repair, tutoring, gardening). You’ll be matched safely and fairly; ratings build your HALO reputation.</p>
-            <ul className="list-disc pl-5 space-y-1 text-white/80">
-              <li>Progressive verification for trust.</li>
-              <li>Proof-of-service + random audits; no exploitation.</li>
-              <li>Earn non-speculative HALO credits for impact.</li>
-            </ul>
-          </div>
-        )}
-        <p className="mt-6 text-white/70 text-sm">Change what helps you today — and help someone else tomorrow. That’s the HALO loop.</p>
+        <div
+          role="tabpanel"
+          id={`${panelBaseId}-${activeContent.id}`}
+          aria-labelledby={`${tablistId}-${activeContent.id}`}
+          className="space-y-6 rounded-3xl border border-white/[0.08] bg-white/[0.04] p-8 text-base text-cloud/80 shadow-[0_18px_48px_-36px_rgba(15,23,42,0.9)]"
+        >
+          <p className="text-lg text-cloud/90">{activeContent.intro}</p>
+          <ul className="space-y-2.5">
+            {activeContent.points.map((point) => (
+              <li key={point} className="flex gap-3 text-cloud/75">
+                <span className="mt-1 inline-flex h-1.5 w-1.5 flex-none rounded-full bg-cloud/60" aria-hidden="true" />
+                <span>{point}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <p className="text-sm text-cloud/60">
+          Currently viewing: {activeContent.label} perspective.
+        </p>
       </div>
-    </section>
+      <span className="sr-only" aria-live="polite">
+        {`Showing ${activeContent.label} perspective`}
+      </span>
+    </div>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,15 +6,33 @@ export default {
     "./components/**/*.{ts,tsx}"
   ],
   theme: {
+    container: {
+      center: true,
+      padding: {
+        DEFAULT: "1.5rem",
+        md: "2.5rem",
+      },
+      screens: {
+        "2xl": "72rem",
+      },
+    },
     extend: {
       colors: {
         ink: "#0F172A",
-        halo: "#F59E0B",
-        slate: "#64748B",
         cloud: "#F1F5F9",
-        coral: "#F97316"
-      }
-    }
+        halo: "#F59E0B",
+        slate: "#94A3B8",
+      },
+      fontFamily: {
+        sans: ["Inter", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "sans-serif"],
+      },
+      boxShadow: {
+        lift: "0 18px 60px -30px rgba(15, 23, 42, 0.65)",
+      },
+      borderRadius: {
+        "3xl": "1.75rem",
+      },
+    },
   },
   plugins: [],
 } satisfies Config

--- a/types/process-env.d.ts
+++ b/types/process-env.d.ts
@@ -1,0 +1,10 @@
+declare namespace NodeJS {
+  interface ProcessEnv {
+    RESEND_API_KEY?: string;
+    ADMIN_EMAIL?: string;
+  }
+}
+
+declare const process: {
+  env: NodeJS.ProcessEnv;
+};


### PR DESCRIPTION
## Summary
- redesign the global styles and Tailwind theme with premium ink, halo, and cloud tokens plus reusable section, button, and halo orb utilities
- rebuild the homepage hero, feature grid, role toggle, and trust receipts into refined panels with accessible motion, typography, and waitlist form styling
- refresh the trust & safety and transparency pages into elegant policy layouts and add lightweight environment typings for process variables

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: npm cannot download @types/node in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e2c35d717c8330812a7c2d74df2d57