### PR TITLE
Add CI workflow for automatic Vercel deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy to Vercel
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Next.js app
+        run: npm run build
+
+      - name: Pull Vercel environment information
+        run: npx vercel pull --yes --environment=production --token ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Create production build
+        run: npx vercel build --prod --token ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to production
+        run: npx vercel deploy --prebuilt --prod --yes --token ${{ secrets.VERCEL_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ pnpm dev # or npm run dev
    - `ADMIN_EMAIL` = hello@halohub.com (or your admin inbox)
 3. Deploy. If `RESEND_API_KEY` is not set, the waitlist form still works (no-op server email).
 
+### Continuous deployment from `master`
+
+Merges to `master` automatically build and deploy via GitHub Actions. Configure the following
+repository secrets so the workflow can authenticate with Vercel:
+
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+
+Once the secrets are set, every push to `master` will run `npm run build`, create a production
+bundle with `vercel build`, and deploy it with `vercel deploy --prod`, ensuring the live site is
+updated immediately after PRs are merged.
+
 ## Project Structure
 
 - `app/` — App Router pages and API route


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Next.js app and deploys it to Vercel whenever `master` is updated
- document the required Vercel secrets in the README so the deployment can authenticate and run

## Testing
- npm run build *(fails: npm registry returned 403 for @types/node during Next.js type checks in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e2dd770c708330a7c87c4ffaf46676