### PR TITLE
Add optional Supabase integration for waitlist storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,30 @@ pnpm dev # or npm run dev
 ## Deploy (Vercel)
 
 1. Create a new project and import this repo.
-2. Add **Environment Variables** (optional for emails):
+2. Add **Environment Variables** (optional for emails/database):
    - `RESEND_API_KEY` = your API key (optional, enables transactional emails)
    - `ADMIN_EMAIL` = hello@halohub.com (or your admin inbox)
+   - `SUPABASE_URL` = project URL (e.g., `https://xyzcompany.supabase.co`)
+   - `SUPABASE_SERVICE_ROLE_KEY` = service role key used for server-side inserts
 3. Deploy. If `RESEND_API_KEY` is not set, the waitlist form still works (no-op server email).
+
+### Optional: Capture signups in Supabase
+
+1. In your Supabase project, create a `signups` table:
+
+   ```sql
+   create table if not exists public.signups (
+     id uuid primary key default gen_random_uuid(),
+     email text not null,
+     role text not null,
+     source text,
+     created_at timestamptz not null default now()
+   );
+   ```
+
+2. Keep Row Level Security enabled and add a policy that allows inserts from the service role key (default behaviour).
+3. Add `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` to your Vercel project (or use an anon key if your policies allow it).
+4. Submissions to `/api/subscribe` will be inserted into the `signups` table alongside email delivery via Resend (if configured).
 
 ### Continuous deployment from `master`
 

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -11,6 +11,29 @@ export async function POST(req: NextRequest) {
     }
     const resendKey = process.env.RESEND_API_KEY;
     const adminEmail = process.env.ADMIN_EMAIL || 'hello@halohub.com';
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+
+    if (supabaseUrl && supabaseKey) {
+      try {
+        const response = await fetch(`${supabaseUrl}/rest/v1/signups`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            apikey: supabaseKey,
+            Authorization: `Bearer ${supabaseKey}`,
+            Prefer: 'return=minimal',
+          },
+          body: JSON.stringify({ email, role, source: 'web' }),
+        });
+        if (!response.ok) {
+          console.error('[supabase] failed to insert signup', await response.text());
+        }
+      } catch (insertError) {
+        console.error('[supabase] error inserting signup', insertError);
+      }
+    }
+
     if (resendKey) {
       const resend = new Resend(resendKey);
       await resend.emails.send({ from: 'HaloHub <noreply@halohub.com>', to: adminEmail, subject: 'New pilot signup', text: `Email: ${email}\nRole: ${role}` });


### PR DESCRIPTION
## Summary
- add optional Supabase REST insert to the signup API route so captured emails can persist in a database
- document the Supabase environment variables and schema setup in the README for Vercel deployments

## Testing
- npm run build *(fails: environment cannot download @types/node from registry)*

------
https://chatgpt.com/codex/tasks/task_b_68e40040f440833093d273deb86ae559