### PR TITLE
Add Node type definitions for TypeScript builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "resend": "4.0.0"
   },
   "devDependencies": {
+    "@types/node": "20.14.12",
     "@types/react": "19.2.0",
     "autoprefixer": "10.4.20",
     "postcss": "8.4.41",


### PR DESCRIPTION
## Summary
- add @types/node to the project's devDependencies so TypeScript tooling is available during builds

## Testing
- npm run build *(fails in the container when npm tries to download @types/node because the npm registry is blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68e407cb577c83308c53b20a7dd9b833